### PR TITLE
 docs(Readme): document line embedding line numbers correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Options:
 
 ### Partial Snippets
 
-Very often you only want to highlight a small part of a file, to do so simply suffix the filename with the Gitlab line
-number syntax, e.g. `path/to/my/file.ts#L20-30`.
+Very often you only want to highlight a small part of a file, to do so simply suffix the filename with the GitHub line
+number syntax, e.g. `path/to/my/file.ts#L20-L30`.
 
 ### Multi Language
 


### PR DESCRIPTION
Documentation for embedding a subset of line numbers in a file specifies
listing a snippet of code in the form `file#L0-10`, but the form
expected by the library is `file#L0-L10`.