### PR TITLE
feat(Embed): allow embedding files without an extension

### DIFF
--- a/src/embedme.lib.ts
+++ b/src/embedme.lib.ts
@@ -225,7 +225,7 @@ function getReplacement(
     return substr;
   }
 
-  const matches = commentedFilename.match(/\s?(\S+?\.\S+?)((#L(\d+)-L(\d+))|$)/m);
+  const matches = commentedFilename.match(/\s?(\S+?)((#L(\d+)-L(\d+))|$)/m);
 
   if (!matches) {
     log({ returnSnippet: substr }, chalk.gray(`No file found in first comment block`));

--- a/test/fixture.md
+++ b/test/fixture.md
@@ -261,6 +261,16 @@ object HelloWorld {
 
 ```
 
+## Extension-less selection
+
+```sh
+# sample
+
+#!/usr/bin/env bash
+print Hello World
+
+```
+
 ## Line selection
 
 ```cs

--- a/test/sample
+++ b/test/sample
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+print Hello World


### PR DESCRIPTION
Sometimes files don't have extensions. Since language inferencing comes
from the code block language, it's easy to allow embedding of
extension-less files by reducing the strictness of the file matching
regex.