### PR TITLE
fix(Rust): incorrect code block signature for rust

### DIFF
--- a/src/embedme.lib.ts
+++ b/src/embedme.lib.ts
@@ -46,7 +46,7 @@ enum SupportedFileType {
   TYPESCRIPT = 'ts',
   JAVASCRIPT = 'js',
   SCSS = 'scss',
-  RUST = 'rs',
+  RUST = 'rust',
   JAVA = 'java',
   CPP = 'cpp',
   C = 'c',

--- a/test/fixture.md
+++ b/test/fixture.md
@@ -46,7 +46,7 @@ print('Hello World')
 
 Rust
 
-```rs
+```rust
 // sample.rs
 
 fn main() {


### PR DESCRIPTION
A code block will correctly syntax highlight Rust code with the `rust`
code block signature, not `rs`; this is understandably confusing because
the file extensions differ here.

Perhaps it would be worth renaming the `SupportedFileType` enum to
something like `SupportedCodeBlock` to more accurately reflect what it
is matching later on.