### PR TITLE
fix(lib): use String#slice instead of String#substr for diff check

### DIFF
--- a/src/embedme.lib.ts
+++ b/src/embedme.lib.ts
@@ -327,7 +327,7 @@ function getReplacement(
     return substr;
   }
 
-  if (replacement.substr(-3).trimRight() === substr.substr(-3).trimRight()) {
+  if (replacement.slice(0, -3).trimRight() === substr.slice(0, -3).trimRight()) {
     log({ returnSnippet: substr }, chalk.gray(`Changes are trailing whitespace only, ignoring`));
     return substr;
   }


### PR DESCRIPTION
`String#substr(-3)` returns the last three characters of a string, which
in a code block is always <code>```</code>. Use `String#slice(0, -3)` instead to
give everything but the last three characters.

Issue close #24