### PR TITLE
feat(Language Support): Support SQL scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Here's a list of file types supported by this utility, if you have a need for an
 contribute, it is easy!
 
 ```ts
-// src/embedme.lib.ts#L44-L75
+// src/embedme.lib.ts#L44-L76
 
 enum SupportedFileType {
   PLAIN_TEXT = 'txt',
@@ -112,6 +112,7 @@ enum SupportedFileType {
   MERMAID = 'mermaid',
   CMAKE = 'cmake',
   PROTOBUF = 'proto',
+  SQL = 'sql',
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/node": "12.0.8",
     "cz-conventional-changelog": "2.1.0",
     "prettier": "1.18.2",
-    "semantic-release": "^15.13.24",
+    "semantic-release": "15.13.16",
     "typescript": "3.5.2"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/node": "12.0.8",
     "cz-conventional-changelog": "2.1.0",
     "prettier": "1.18.2",
-    "semantic-release": "15.13.16",
+    "semantic-release": "^15.13.24",
     "typescript": "3.5.2"
   },
   "config": {

--- a/src/embedme.lib.ts
+++ b/src/embedme.lib.ts
@@ -72,6 +72,7 @@ enum SupportedFileType {
   MERMAID = 'mermaid',
   CMAKE = 'cmake',
   PROTOBUF = 'proto',
+  SQL = 'sql',
 }
 
 enum CommentFamily {
@@ -81,6 +82,7 @@ enum CommentFamily {
   HASH,
   SINGLE_QUOTE,
   DOUBLE_PERCENT,
+  DOUBLE_HYPHENS,
 }
 
 const languageMap: Record<CommentFamily, SupportedFileType[]> = {
@@ -116,6 +118,7 @@ const languageMap: Record<CommentFamily, SupportedFileType[]> = {
   ],
   [CommentFamily.SINGLE_QUOTE]: [SupportedFileType.PLANT_UML],
   [CommentFamily.DOUBLE_PERCENT]: [SupportedFileType.MERMAID],
+  [CommentFamily.DOUBLE_HYPHENS]: [SupportedFileType.SQL],
 };
 
 const leadingSymbol = (symbol: string): FilenameFromCommentReader => line => {
@@ -143,6 +146,7 @@ const filetypeCommentReaders: Record<CommentFamily, FilenameFromCommentReader> =
   [CommentFamily.HASH]: leadingSymbol('#'),
   [CommentFamily.SINGLE_QUOTE]: leadingSymbol(`'`),
   [CommentFamily.DOUBLE_PERCENT]: leadingSymbol('%%'),
+  [CommentFamily.DOUBLE_HYPHENS]: leadingSymbol('--'),
 };
 
 function lookupLanguageCommentFamily(fileType: SupportedFileType): CommentFamily | null {

--- a/test/fixture-source.md
+++ b/test/fixture-source.md
@@ -177,6 +177,12 @@ CMake
 # sample.cmake
 ```
 
+SQL Script
+
+```sql
+-- sample.sql
+```
+
 ## Extension-less selection
 
 ```sh

--- a/test/fixture.md
+++ b/test/fixture.md
@@ -349,6 +349,16 @@ add_executable(hello sample.cpp)
 
 ```
 
+SQL Script
+
+```sql
+-- sample.sql
+
+SELECT *
+FROM tableUsers
+WHERE 1=1
+```
+
 ## Extension-less selection
 
 ```sh

--- a/test/sample.sql
+++ b/test/sample.sql
@@ -1,0 +1,3 @@
+SELECT * 
+FROM tableUsers
+WHERE 1=1


### PR DESCRIPTION
Hi dear, SQL is one of languages supported by github flavored markdown, so I decide to add this feature in this great project. Sorry if lost somthing on tests, but I tried hard. 
I have some SQL scripts in my ETL project to perform some machine learning tasks. Last week I tried to update my markdown and noticed that this language was not there.